### PR TITLE
HTTP_Engine: Mark GetRequest as obsolete and change back to public

### DIFF
--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using System.Collections.Generic;
 using System.Net.Http;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.HTTP
 {
@@ -31,7 +32,7 @@ namespace BH.Engine.HTTP
         /***************************************************/
         /**** Private  Methods                          ****/
         /***************************************************/
-        [System.Obsolete("GetRequest is deprecated, pit does not comply with BHoM Adaptor Push and Pull protocols")]
+        [Deprecated("3.1", "Does not comply with BHoM Adaptor Push and Pull protocols"]
         public static string GetRequest(string uri)
         {
             using (HttpResponseMessage response = new HttpClient().GetAsync(uri).Result)

--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -31,8 +31,8 @@ namespace BH.Engine.HTTP
         /***************************************************/
         /**** Private  Methods                          ****/
         /***************************************************/
-
-        private static string GetRequest(string uri)
+        [System.Obsolete("GetRequest is deprecated, pit does not comply with BHoM Adaptor Push and Pull protocols")]
+        public static string GetRequest(string uri)
         {
             using (HttpResponseMessage response = new HttpClient().GetAsync(uri).Result)
             {

--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -32,7 +32,7 @@ namespace BH.Engine.HTTP
         /***************************************************/
         /**** Private  Methods                          ****/
         /***************************************************/
-        [Deprecated("3.1", "Does not comply with BHoM Adaptor Push and Pull protocols"]
+        [Deprecated("3.1", "Does not comply with BHoM Adaptor Push and Pull protocols")]
         public static string GetRequest(string uri)
         {
             using (HttpResponseMessage response = new HttpClient().GetAsync(uri).Result)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
Closes #34 
marks the GetRequest method as obsolete with explanation and allows continued use by changing the method to public  