### PR TITLE
Fixed baseUrl behavior to support direct parameter string inputs and changed framework to 4.5.2

### DIFF
--- a/HTTP_Adapter/HTTP_Adapter.csproj
+++ b/HTTP_Adapter/HTTP_Adapter.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.HTTP</RootNamespace>
     <AssemblyName>HTTP_Adapter</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/HTTP_Adapter/HTTP_Adapter.csproj
+++ b/HTTP_Adapter/HTTP_Adapter.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -66,7 +66,7 @@ namespace BH.Engine.HTTP
                 }
             }
 
-            using (HttpResponseMessage response = client.GetAsync(uri,HttpCompletionOption.ResponseContentRead).Result)
+            using (HttpResponseMessage response = client.GetAsync(uri, HttpCompletionOption.ResponseContentRead).Result)
             {
                 string result = response.Content.ReadAsStringAsync().Result;
                 if (!response.IsSuccessStatusCode)

--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -66,7 +66,7 @@ namespace BH.Engine.HTTP
                 }
             }
 
-            using (HttpResponseMessage response = client.GetAsync(uri).Result)
+            using (HttpResponseMessage response = client.GetAsync(uri,HttpCompletionOption.ResponseContentRead).Result)
             {
                 string result = response.Content.ReadAsStringAsync().Result;
                 if (!response.IsSuccessStatusCode)

--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -66,11 +66,7 @@ namespace BH.Engine.HTTP
                 }
             }
 
-            //Create request
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
-
-
-            using (HttpResponseMessage response = client.SendAsync(request).Result)
+            using (HttpResponseMessage response = client.GetAsync(uri).Result)
             {
                 string result = response.Content.ReadAsStringAsync().Result;
                 if (!response.IsSuccessStatusCode)

--- a/HTTP_Engine/Compute/GetRequestAsync.cs
+++ b/HTTP_Engine/Compute/GetRequestAsync.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.HTTP
             if (client == null)
                 client = new HttpClient();
 
-            using (HttpResponseMessage response = await client.GetAsync(uri).ConfigureAwait(false))
+            using (HttpResponseMessage response = await client.GetAsync(uri, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false))
             {
                 string result = await response.Content.ReadAsStringAsync();
                 if (!response.IsSuccessStatusCode)

--- a/HTTP_Engine/Convert/ToUrlString.cs
+++ b/HTTP_Engine/Convert/ToUrlString.cs
@@ -35,25 +35,35 @@ namespace BH.Engine.HTTP
         /***************************************************/
 
         public static string ToUrlString(this GetRequest request)
-        {
-            UriBuilder builder = new UriBuilder(request.BaseUrl);
+        {           
             if (request.Parameters != null)
             {
+                UriBuilder builder = new UriBuilder(request.BaseUrl);
                 builder.Query = Convert.ToUrlString(request.Parameters);
+                return builder.Uri.AbsoluteUri;
             }
-            return builder.Uri.AbsoluteUri;
+            else
+            {
+                return request.BaseUrl;
+            }
         }
 
         /***************************************************/
 
-        public static string ToUrlString(string baseUrl, Dictionary<string, object> parameters)
+        public static string ToUrlString(string baseUrl, Dictionary<string, object> parameters = null)
         {
-            UriBuilder builder = new UriBuilder(baseUrl)
+            if (parameters != null)
             {
-                Query = parameters == null ? "" : Convert.ToUrlString(parameters)
-            };
-
-            return builder.Uri.AbsoluteUri;
+                UriBuilder builder = new UriBuilder(baseUrl)
+                {
+                    Query = parameters == null ? "" : Convert.ToUrlString(parameters)
+                };
+                return builder.Uri.AbsoluteUri;
+            }
+            else
+            {
+                return baseUrl;
+            }          
         }
 
         /***************************************************/

--- a/HTTP_Engine/HTTP_Engine.csproj
+++ b/HTTP_Engine/HTTP_Engine.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/HTTP_Engine/HTTP_Engine.csproj
+++ b/HTTP_Engine/HTTP_Engine.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.HTTP</RootNamespace>
     <AssemblyName>HTTP_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/HTTP_oM/HTTP_oM.csproj
+++ b/HTTP_oM/HTTP_oM.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.oM.HTTP</RootNamespace>
     <AssemblyName>HTTP_oM</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/HTTP_oM/HTTP_oM.csproj
+++ b/HTTP_oM/HTTP_oM.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #36 
Closes #22 

GetRequests can now include parameters as part of the base string instead of as parameters. They also wait for content response completion, which was a previously undetected bug (in this case, the github response could contain incomplete responses with only one or two objects instead of seven).

Framework has also been reverted to 4.5.2 as there is no need for an advanced framework.


### Test files
[TestBaseURLWithParameters.zip](https://github.com/BHoM/HTTP_Toolkit/files/4350950/TestBaseURLWithParameters.zip)

