### PR TITLE
Add binary response reading option

### DIFF
--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -68,7 +68,6 @@ namespace BH.Engine.HTTP
 
             using (HttpResponseMessage response = client.GetAsync(uri, HttpCompletionOption.ResponseContentRead).Result)
             {
-                string result = response.Content.ReadAsStringAsync().Result;
                 if (!response.IsSuccessStatusCode)
                 {
                     Engine.Reflection.Compute.ClearCurrentEvents();
@@ -77,6 +76,7 @@ namespace BH.Engine.HTTP
                 }
                 else
                 {
+                    string result = response.Content.ReadAsStringAsync().Result;
                     return result;
                 }
             }
@@ -107,7 +107,6 @@ namespace BH.Engine.HTTP
 
             using (HttpResponseMessage response = client.GetAsync(uri, HttpCompletionOption.ResponseContentRead).Result)
             {
-                byte[] result = response.Content.ReadAsByteArrayAsync().Result;
                 if (!response.IsSuccessStatusCode)
                 {
                     Engine.Reflection.Compute.ClearCurrentEvents();
@@ -116,6 +115,7 @@ namespace BH.Engine.HTTP
                 }
                 else
                 {
+                    byte[] result = response.Content.ReadAsByteArrayAsync().Result;
                     return result;
                 }
             }

--- a/HTTP_Engine/Compute/GetRequest.cs
+++ b/HTTP_Engine/Compute/GetRequest.cs
@@ -92,6 +92,45 @@ namespace BH.Engine.HTTP
 
         /***************************************************/
 
+        private static byte[] GetRequestBinary(string uri, Dictionary<string, object> headers = null)
+        {
+            HttpClient client = new HttpClient();
+
+            //Add headers
+            if (headers != null)
+            {
+                foreach (var kvp in headers)
+                {
+                    client.DefaultRequestHeaders.Add(kvp.Key, kvp.Value.ToString());
+                }
+            }
+
+            using (HttpResponseMessage response = client.GetAsync(uri, HttpCompletionOption.ResponseContentRead).Result)
+            {
+                byte[] result = response.Content.ReadAsByteArrayAsync().Result;
+                if (!response.IsSuccessStatusCode)
+                {
+                    Engine.Reflection.Compute.ClearCurrentEvents();
+                    Engine.Reflection.Compute.RecordError($"GET request failed with code {response.StatusCode}: {response.ReasonPhrase}");
+                    return null;
+                }
+                else
+                {
+                    return result;
+                }
+            }
+        }
+
+        /***************************************************/
+
+        private static byte[] GetRequestBinary(string baseUrl, Dictionary<string, object> headers = null, Dictionary<string, object> parameters = null)
+        {
+            string uri = Convert.ToUrlString(baseUrl, parameters);
+            return GetRequestBinary(uri, headers);
+        }
+
+        /***************************************************/
+
     }
 }
 

--- a/HTTP_Engine/Compute/MakeRequest.cs
+++ b/HTTP_Engine/Compute/MakeRequest.cs
@@ -43,6 +43,13 @@ namespace BH.Engine.HTTP
 
         /***************************************************/
 
+        public static byte[] MakeRequestBinary(GetRequest request)
+        {
+            return GetRequestBinary(request.BaseUrl, request.Headers, request.Parameters);
+        }
+
+        /***************************************************/
+
     }
 }
 


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

CLoses #49 

Added a method to read GetRequest responses and return a byte array, so that we can use HTTP_Toolkit with binary files such as image files pulled from an endpoint.


### Test files
Any previous test script with MakeRequest, replacing it with MakeRequestBinary to check that it works with a binary return value.
