### PR TITLE
Fix security protocols

### DIFF
--- a/HTTP_Adapter/HttpAdapter.cs
+++ b/HTTP_Adapter/HttpAdapter.cs
@@ -40,11 +40,9 @@ namespace BH.Adapter.HTTP
 
         public HTTPAdapter()
         {
-            System.Net.ServicePointManager.SecurityProtocol =
-                SecurityProtocolType.Ssl3 |
-                SecurityProtocolType.Tls12 |
-                SecurityProtocolType.Tls11 |
-                SecurityProtocolType.Tls;
+            // Use TLS 1.2 and TLS 1.3 (if available). Deprecated protocols not supported any longer: SSL3, TLS 1.0, TLS 1.1.
+            // TLS 1.2 is widely supported and secure. TLS 1.3 may not be available in all .NET Framework versions.
+            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 |  (SecurityProtocolType)3072; // 3072 = Tls13
         }
 
         /***************************************************/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #115

Base on the test files provided by @michaelhoehn (see test files section), the following exception was thrown when trying to create an HTTP adapter in Rhino 8: `System.NotSupportedException: The requested security protocol is not supported.`

This PR fixes that by updating the list of protocols used by the adapter. 

### Test files

[HTTP_Sharepoint Test-Rhino 7 and 8.zip](https://github.com/user-attachments/files/23452413/HTTP_Sharepoint.Test-Rhino.7.and.8.zip)

